### PR TITLE
Upgraded to spring boot 3.x and qpid 2.x to move over to the jakarta …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,15 +79,15 @@
   </modules>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.resources.sourceEncoding>UTF-8</project.resources.sourceEncoding>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- qpid-jms-client -->
-    <qpid-jms.version>0.55.0</qpid-jms.version>
-    <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
+    <qpid-jms.version>2.1.0</qpid-jms.version>
+    <spring-boot.version>3.0.1</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/qpid-jms-spring-boot-autoconfigure/pom.xml
+++ b/qpid-jms-spring-boot-autoconfigure/pom.xml
@@ -59,6 +59,13 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/jakarta.jms/jakarta.jms-api -->
+    <dependency>
+      <groupId>jakarta.jms</groupId>
+      <artifactId>jakarta.jms-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/qpid-jms-spring-boot-autoconfigure/src/main/java/com/youkol/support/qpid/jms/spring/boot/autoconfigure/QpidJmsAutoConfiguration.java
+++ b/qpid-jms-spring-boot-autoconfigure/src/main/java/com/youkol/support/qpid/jms/spring/boot/autoconfigure/QpidJmsAutoConfiguration.java
@@ -15,8 +15,7 @@
  */
 package com.youkol.support.qpid.jms.spring.boot.autoconfigure;
 
-import javax.jms.ConnectionFactory;
-
+import jakarta.jms.ConnectionFactory;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;

--- a/qpid-jms-spring-boot-autoconfigure/src/main/java/com/youkol/support/qpid/jms/spring/boot/autoconfigure/QpidJmsConnectionFactoryConfiguration.java
+++ b/qpid-jms-spring-boot-autoconfigure/src/main/java/com/youkol/support/qpid/jms/spring/boot/autoconfigure/QpidJmsConnectionFactoryConfiguration.java
@@ -17,8 +17,7 @@ package com.youkol.support.qpid.jms.spring.boot.autoconfigure;
 
 import java.util.stream.Collectors;
 
-import javax.jms.ConnectionFactory;
-
+import jakarta.jms.ConnectionFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;


### PR DESCRIPTION
In order to move over fra javax to jakarta namespace spring boot and qpid need to be upgraded